### PR TITLE
fix: normalized map issue

### DIFF
--- a/lokdhaba_js/src/Components/DataVisualization.js
+++ b/lokdhaba_js/src/Components/DataVisualization.js
@@ -276,6 +276,7 @@ export default class DataVisualization extends Component {
       ,showVisualization: false
       , showBaseMap: true
       ,showChangeMap: false
+      ,showNormalizedMap: false
       ,vizOptionsSelected: new Set()
       ,year: ""
       , visualizationType: visualizationType }, async () => {


### PR DESCRIPTION
Fixes issue where selecting the normalized map option then switching to a different visualization caused all the constituencies to be coloured in black