### PR TITLE
feat: Add components to present error screen when dataviz crashes

### DIFF
--- a/lokdhaba_js/src/Components/DataVisualization.js
+++ b/lokdhaba_js/src/Components/DataVisualization.js
@@ -8,14 +8,14 @@ import Checkbox from './Shared/Checkbox.js';
 import LdSelect from './Shared/Select.js';
 import DataVizWrapper from './Shared/DataVizWrapper';
 import * as Constants from './Shared/Constants.js';
+import ErrorScreen from "./Shared/ErrorScreen.js";
+import ErrorBoundary from "./Shared/ErrorBoundary.js";
 import Popup from './Shared/Popup.js';
 import { CSVLink } from "react-csv";
 import { Button } from 'react-bootstrap';
 import $ from 'jquery';
 import { components } from "react-select";
 import Select from "react-select";
-import ErrorScreen from "./Shared/ErrorScreen.js";
-import ErrorBoundary from "./Shared/ErrorBoundary.js";
 
 function compareValues(key, order = 'asc') {
   return function innerSort(a, b) {

--- a/lokdhaba_js/src/Components/DataVisualization.js
+++ b/lokdhaba_js/src/Components/DataVisualization.js
@@ -278,6 +278,7 @@ export default class DataVisualization extends Component {
       ,showVisualization: false
       , showBaseMap: true
       ,showChangeMap: false
+      ,showNormalizedMap: false
       ,vizOptionsSelected: new Set()
       ,year: ""
       , visualizationType: visualizationType }, async () => {

--- a/lokdhaba_js/src/Components/DataVisualization.js
+++ b/lokdhaba_js/src/Components/DataVisualization.js
@@ -15,6 +15,7 @@ import $ from 'jquery';
 import { components } from "react-select";
 import Select from "react-select";
 import ErrorScreen from "./Shared/ErrorScreen.js";
+import ErrorBoundary from "./Shared/ErrorBoundary.js";
 
 function compareValues(key, order = 'asc') {
   return function innerSort(a, b) {
@@ -750,30 +751,32 @@ export default class DataVisualization extends Component {
     }
 
     return (
-      <DataVizWrapper
-        visualization={visualization}
-        visualizationType={visualizationType}
-        data={data}
-        map={shape}
-        party = {party}
-        electionType={electionType}
-        assemblyNo={assemblyNo}
-        stateName={stateName}
-        showMapYearOptions={true}
-        yearOptions={yearOptions}
-        chartMapOptions={chartMapOptions}
-        dataFilterOptions={dataFilterOptions}
-        playChangeYears={this.playChangeYears}
-        onMapYearChange={this.onMapYearChange}
-        showChangeMap={showChangeMap}
-        onShowChangeMapChange={this.onShowChangeMapChange}
-        showBaseMap = {showBaseMap}
-        onShowBaseMapChange = {this.onShowBaseMapChange}
-        showNormalizedMap={showNormalizedMap}
-        onShowNormalizedMapChange={this.onShowNormalizedMapChange}
-        segmentWise={segmentWise}
-        mapOverlay = {mapOverlay}
-      />
+      <ErrorBoundary>
+        <DataVizWrapper
+          visualization={visualization}
+          visualizationType={visualizationType}
+          data={data}
+          map={shape}
+          party = {party}
+          electionType={electionType}
+          assemblyNo={assemblyNo}
+          stateName={stateName}
+          showMapYearOptions={true}
+          yearOptions={yearOptions}
+          chartMapOptions={chartMapOptions}
+          dataFilterOptions={dataFilterOptions}
+          playChangeYears={this.playChangeYears}
+          onMapYearChange={this.onMapYearChange}
+          showChangeMap={showChangeMap}
+          onShowChangeMapChange={this.onShowChangeMapChange}
+          showBaseMap = {showBaseMap}
+          onShowBaseMapChange = {this.onShowBaseMapChange}
+          showNormalizedMap={showNormalizedMap}
+          onShowNormalizedMapChange={this.onShowNormalizedMapChange}
+          segmentWise={segmentWise}
+          mapOverlay = {mapOverlay}
+        />
+      </ErrorBoundary>
     );
   }
 

--- a/lokdhaba_js/src/Components/DataVisualization.js
+++ b/lokdhaba_js/src/Components/DataVisualization.js
@@ -14,6 +14,7 @@ import { Button } from 'react-bootstrap';
 import $ from 'jquery';
 import { components } from "react-select";
 import Select from "react-select";
+import ErrorScreen from "./Shared/ErrorScreen.js";
 
 function compareValues(key, order = 'asc') {
   return function innerSort(a, b) {
@@ -740,6 +741,14 @@ export default class DataVisualization extends Component {
     var assemblyNo = this.state.year;
     const { visualizationType, yearOptions, chartMapOptions, showChangeMap, showBaseMap, showNormalizedMap, party, showVisualization, segmentWise, mapOverlay } = this.state;
 
+    if (!data) {
+      return (
+        <ErrorScreen
+          message="An error occured while trying to get this data."
+        />
+      )
+    }
+
     return (
       <DataVizWrapper
         visualization={visualization}
@@ -767,6 +776,7 @@ export default class DataVisualization extends Component {
       />
     );
   }
+
   onAssemblyNoChange = (newValue) => {
     this.setState({showVisualization: false, year : newValue},async ()=>{
 

--- a/lokdhaba_js/src/Components/Shared/ErrorBoundary.js
+++ b/lokdhaba_js/src/Components/Shared/ErrorBoundary.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 import ErrorScreen from './ErrorScreen.js';
 
+// Component that wraps a returned UI component and presents an error screen if the UI component throws an error
 class ErrorBoundary extends React.Component {
 
   constructor(props) {
@@ -10,17 +11,17 @@ class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, info) {
-    // Display fallback UI
     this.setState({ 
       hasError: true 
     });
 
-    // You can also log the error to an error reporting service
-    console.log(error, info);
+    // TODO: where to log errors?
+    // console.log(error, info);
   }
 
   render() {
     if (this.state.hasError) {
+      // return fallback UI
       return (
         <ErrorScreen
           message="An error occured while trying to get this data."

--- a/lokdhaba_js/src/Components/Shared/ErrorBoundary.js
+++ b/lokdhaba_js/src/Components/Shared/ErrorBoundary.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+
+import ErrorScreen from './ErrorScreen.js';
+
+class ErrorBoundary extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch(error, info) {
+    // Display fallback UI
+    this.setState({ 
+      hasError: true 
+    });
+
+    // You can also log the error to an error reporting service
+    console.log(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <ErrorScreen
+          message="An error occured while trying to get this data."
+        />
+      );    
+    }    
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/lokdhaba_js/src/Components/Shared/ErrorScreen.js
+++ b/lokdhaba_js/src/Components/Shared/ErrorScreen.js
@@ -2,13 +2,13 @@ import React, { Component } from 'react';
 import '../../Assets/Styles/select.css';
 
 const ErrorScreen = (props) => {
-	return (
-		<div style={{color: "red", display: "flex", justifyContent: "center", alignItems: "center", height: "100%", textAlign: "center"}}>
-        	{props.message}
-        	<br/>
-        	Please refresh the page and try again.
-        </div>
-	)
+  return (
+    <div style={{color: "red", display: "flex", justifyContent: "center", alignItems: "center", height: "100%", textAlign: "center"}}>
+      {props.message}
+      <br/>
+      Please refresh the page and try again.
+    </div>
+  )
 }
 
 export default ErrorScreen;

--- a/lokdhaba_js/src/Components/Shared/ErrorScreen.js
+++ b/lokdhaba_js/src/Components/Shared/ErrorScreen.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
 import '../../Assets/Styles/select.css';
 
+// Fallback UI component that's displayed instead of a React error
 const ErrorScreen = (props) => {
   return (
     <div style={{color: "red", display: "flex", justifyContent: "center", alignItems: "center", height: "100%", textAlign: "center"}}>
+    	{/* Customizable message that must be passed to the component when calling */}
       {props.message}
       <br/>
       Please refresh the page and try again.

--- a/lokdhaba_js/src/Components/Shared/ErrorScreen.js
+++ b/lokdhaba_js/src/Components/Shared/ErrorScreen.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import '../../Assets/Styles/select.css';
+
+const ErrorScreen = (props) => {
+	return (
+		<div style={{color: "red", display: "flex", justifyContent: "center", alignItems: "center", height: "100%", textAlign: "center"}}>
+        	{props.message}
+        	<br/>
+        	Please refresh the page and try again.
+        </div>
+	)
+}
+
+export default ErrorScreen;


### PR DESCRIPTION
Addresses #11 in the LD issues doc

Adds two components, ErrorBoundary.js and ErrorScreen.js
ErrorBoundary.js is a component that wraps DataVizWrapper and intercepts any errors that are thrown
ErrorScreen.js is a customizable UI component that is presented when the app crashes or when no data is found